### PR TITLE
other record of customized domain fixed

### DIFF
--- a/src/dns-server.iced
+++ b/src/dns-server.iced
@@ -81,7 +81,7 @@ class DnsServer
 
         for question in request.question
 
-            entries = @entries.findEntries question.name
+            entries = @entries.findEntries question.name, question.type
             if entries.length
                 for entry in entries
                     record =

--- a/src/entrylist.iced
+++ b/src/entrylist.iced
@@ -29,7 +29,7 @@ class EntryList
         catch error
             logger.error "could not parse DNS record", data, error
 
-    findEntries: (name) ->
-        (entry for entry in @entries when entry.domainRegex.exec name)
+    findEntries: (name, type) ->
+        (entry for entry in @entries when ((entry.domainRegex.exec name) and (recordTable[entry.type] is type)))
 
 module.exports = EntryList

--- a/src/record-table.iced
+++ b/src/record-table.iced
@@ -1,0 +1,11 @@
+# Just some common use record
+# Full table in https://en.wikipedia.org/wiki/List_of_DNS_record_types
+module.exports = 
+    A : 1,
+    AAAA: 28,
+    MX: 15,
+    NS: 2,
+    PTR: 12,
+    SOA: 6,
+    SRV: 33,
+    TXT: 16


### PR DESCRIPTION
For example we customize `*.3osmp.mongodb.net:A:1.2.3.4 -u 8.8.8.8`.
App must just customize **A** query of this domains but current app answer all queries with this response
```
IN A 1.2.3.4
```

I fixed this bug.